### PR TITLE
Add itemize to doc, fix installation script (run pdflatex three times)

### DIFF
--- a/doc/multlog.md
+++ b/doc/multlog.md
@@ -82,11 +82,17 @@ To run the installation script, change to the installation directory
     ./ml_install
 
 The script will
+
 - determine the location of some Unix commands
+
 - ask the user for the Prolog to use
+
 - ask the user for the place where to put MUltlog
+
 - generate the deinstallation script `ml_deinstall`
+
 - insert the correct paths in some of MUltlog's files
+
 - copy the MUltlog files in the right places.
 
 In case of problems see the section on

--- a/doc/multlog.tex
+++ b/doc/multlog.tex
@@ -177,11 +177,15 @@ To run the installation script, change to the installation directory
 ./ml_install
 \end{lstlisting}
 
-The script will - determine the location of some Unix commands - ask the
-user for the Prolog to use - ask the user for the place where to put
-MUltlog - generate the deinstallation script
-\passthrough{\lstinline!ml\_deinstall!} - insert the correct paths in
-some of MUltlog's files - copy the MUltlog files in the right places.
+The script will
+\begin{itemize}
+\item determine the location of some Unix commands
+\item ask the user for the Prolog to use
+\item ask the user for the place where to put MUltlog
+\item generate the deinstallation script \passthrough{\lstinline!ml\_deinstall!}
+\item insert the correct paths in some of MUltlog's files
+\item copy the MUltlog files in the right places.
+\end{itemize}
 
 In case of problems see the section on
 \protect\hyperlink{troubleshooting}{troubleshooting} below.

--- a/ml_install
+++ b/ml_install
@@ -240,6 +240,8 @@ done
 echo "pdfLaTeXing the manual."
 
 if $ltxpdf; then
+   # Needs three runs to get cross-references right
+   $pdflatex -output-directory $mldoc $mldoc/multlog.tex >/dev/null
    $pdflatex -output-directory $mldoc $mldoc/multlog.tex >/dev/null
    $pdflatex -output-directory $mldoc $mldoc/multlog.tex >/dev/null
    $rm -f $mldoc/multlog.aux $mldoc/multlog.log $mldoc/multlog.toc $mldoc/multlog.out


### PR DESCRIPTION
Not sure, whether the pseudo-inline itemize is intended:
```latex
The script will - determine the location of some Unix commands - ask the
user for the Prolog to use - ask the user for the place where to put
MUltlog - generate the deinstallation script
\passthrough{\lstinline!ml\_deinstall!} - insert the correct paths in
some of MUltlog's files - copy the MUltlog files in the right places.
```
If not: I have modified `multlog.md` as well as `multlog.tex` to transform it to a proper itemize. If one file is generated from the other via `pandoc`, then pick the appropriate file.

Independently of this change, `multlog.tex` needs to be compiled three times in the installation script, not just twice. Probably shouldn't have been the same commit.